### PR TITLE
「Comparisons」ページの翻訳

### DIFF
--- a/guide/comparisons.md
+++ b/guide/comparisons.md
@@ -2,7 +2,7 @@
 
 ## Snowpack
 
-[Snowpack](https://www.snowpack.dev/) も no-bundle ネイティブな ESM の開発サーバーであり、Vite と非常に近い目的を持っています。実装の詳細が異なる点を除き、2つのプロジェクトは伝統的なツールより技術的に優れている点で非常に多くの共通点があります。Vite の依存関係のプリビルドの機能は、Snowpack v1（現在の[`esinstall`](https://github.com/snowpackjs/snowpack/tree/main/esinstall)）にも影響を受けています。2つのプロジェクト間の大きな違いは、以下のような点にあります。
+[Snowpack](https://www.snowpack.dev/) も no-bundle ネイティブな ESM の開発サーバーであり、Vite と非常に近い目的を持っています。実装の詳細が異なる点を除き、2つのプロジェクトは伝統的なツールより技術的に優れている点で非常に多くの共通点があります。Vite の依存関係の先読みビルドの機能は、Snowpack v1（現在の[`esinstall`](https://github.com/snowpackjs/snowpack/tree/main/esinstall)）にも影響を受けています。2つのプロジェクト間の大きな違いは、以下のような点にあります。
 
 **本番ビルド**
 
@@ -19,9 +19,9 @@ Vite では、単一のバンドラー（Rollup）と深く結合することを
 - [自動的な dynamic import の polyfill](./features#dynamic-import-polyfill)
 - 公式の [legacy モードプラグイン](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy)。このプラグインは、modern/legacy のデュアルバンドルを生成し、ブラウザの対応状況をもとに正しいバンドルを自動的に配信します。
 
-**より高速な依存関係のプリビルド**
+**より高速な依存関係の先読みビルド**
 
-Vite は、依存関係のプリビルドのために、[esbuild](https://esbuild.github.io/) ではなく Rollup を使用しています。その結果、コールドサーバーの起動と依存関係の無効化に伴う再バンドルに関して、極めて大きな性能向上が得られました。
+Vite は、依存関係の先読みビルドのために、[esbuild](https://esbuild.github.io/) ではなく Rollup を使用しています。その結果、コールドサーバーの起動と依存関係の無効化に伴う再バンドルに関して、極めて大きな性能向上が得られました。
 
 **Monorepo のサポート**
 

--- a/guide/comparisons.md
+++ b/guide/comparisons.md
@@ -1,50 +1,50 @@
-# Comparisons with Other No-Bundler Solutions
+# 他の No-Bundler ツールとの比較
 
 ## Snowpack
 
-[Snowpack](https://www.snowpack.dev/) is also a no-bundle native ESM dev server that is very similar in scope to Vite. Aside from different implementation details, the two projects share a lot in terms of technical advantages over traditional tooling. Vite's dependency pre-bundling is also inspired by Snowpack v1 (now [`esinstall`](https://github.com/snowpackjs/snowpack/tree/main/esinstall)). Some of the main differences between the two projects are:
+[Snowpack](https://www.snowpack.dev/) も no-bundle ネイティブな ESM の開発サーバーであり、Vite と非常に近い目的を持っています。実装の詳細が異なる点を除き、2つのプロジェクトは伝統的なツールより技術的に優れている点で非常に多くの共通点があります。Vite の依存関係のプリビルドの機能は、Snowpack v1（現在の[`esinstall`](https://github.com/snowpackjs/snowpack/tree/main/esinstall)）にも影響を受けています。2つのプロジェクト間の大きな違いは、以下のような点にあります。
 
-**Production Build**
+**本番ビルド**
 
-Snowpack's default build output is unbundled: it transforms each file into separate built modules, which can then be fed into different "optimizers" that perform the actual bundling. The benefit of this is that you can choose between different end-bundlers to fit specific needs (e.g. webpack, Rollup, or even esbuild), the downside is that it's a bit of a fragmented experience - for example, the esbuild optimizer is still unstable, the Rollup optimizer is not officially maintained, and different optimizers have different output and configurations.
+Snowpack のデフォルトのビルド出力は unbundled です。unbundled では、各ファイルを別々のビルドモジュールに変換し、それらを異なる「オプティマイザー」に入力することで、実際のバンドルを実行できます。この方法の利点は、特定の要求に合う異なる end-bundler（例：webpack、Rollup、あるいは esbuild も）を選択できるという点です。欠点は、開発者経験が多少異なるものとなってしまうことです。たとえば、esbuild オプティマイザーはまだ不安定で、Rollup オプティマイザーは公式にはメンテナンスされておらず、オプティマイザーごとに出力と設定が変わってしまいます。
 
-Vite opts to have a deeper integration with one single bundler (Rollup) in order to provide a more streamlined experience. It also allows Vite to support a [Universal Plugin API](./api-plugin) that works for both dev and build.
+Vite では、単一のバンドラー（Rollup）と深く結合することを選択することで、より効率的な経験が得られるようにしています。また、Vite は [Universal Plugin API](./api-plugin) をサポートしているため、開発時とビルド時の両方で動作します。
 
-Due to a more integrated build process, Vite supports a wide range of features that are currently not available in Snowpack build optimizers:
+より統合されたビルドプロセスを実現するために、Vite では以下のような Snowpack のビルドオプティマイザーでは利用できないような幅広い機能をサポートしています。
 
-- [Multi-Page Support](./build#multi-page-app)
-- [Library Mode](./build#library-mode)
-- [Automatic CSS code-splitting](./features#css-code-splitting)
-- [Optimized async chunk loading](./features#async-chunk-loading-optimization)
-- [Automatic dynamic import polyfill](./features#dynamic-import-polyfill)
-- Official [legacy mode plugin](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) that generates dual modern/legacy bundles and auto delivers the right bundle based on browser support.
+- [Multi-Page のサポート](./build#multi-page-app)
+- [ライブラリモード](./build#library-mode)
+- [自動的な CSS コードの分割](./features#css-code-splitting)
+- [最適化された非同期のチャンク読み込み](./features#async-chunk-loading-optimization)
+- [自動的な dynamic import の polyfill](./features#dynamic-import-polyfill)
+- 公式の [legacy モードプラグイン](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy)。このプラグインは、modern/legacy のデュアルバンドルを生成し、ブラウザの対応状況をもとに正しいバンドルを自動的に配信します。
 
-**Faster Dependency Pre-Bundling**
+**より高速な依存関係のプリビルド**
 
-Vite uses [esbuild](https://esbuild.github.io/) instead of Rollup for dependency pre-bundling. This results in significant performance improvements in terms of cold server start and re-bundling on dependency invalidations.
+Vite は、依存関係のプリビルドのために、[esbuild](https://esbuild.github.io/) ではなく Rollup を使用しています。その結果、コールドサーバーの起動と依存関係の無効化に伴う再バンドルに関して、極めて大きな性能向上が得られました。
 
-**Monorepo Support**
+**Monorepo のサポート**
 
-Vite is designed to handle monorepo setups and we have users successfully using it with Yarn, Yarn 2, and PNPM based monorepos.
+Vite は monorepo のセットアップを意図して設計されており、Yarn、Yarn 2、PNPM ベースの monorepo を上手く使用しているユーザーが存在します。
 
-**CSS Pre-Processor Support**
+**CSS プリプロセッサのサポート**
 
-Vite provides more refined support for Sass and Less, including improved `@import` resolution (aliases and npm dependencies) and [automatic `url()` rebasing for inlined files](./features#import-inlining-and-rebasing).
+Vite は Sass および Less のより洗練されたサポートを提供しています。これには、優れた `@import` の解決（エイリアスおよび npm 依存関係）や、[インラインファイルに対する自動的な `url()` のリベース](./features#import-inlining-and-rebasing)などがあります。
 
-**First Class Vue Support**
+**第1級の Vue サポート**
 
-Vite was initially created to serve as the future foundation of [Vue.js](https://vuejs.org/) tooling. Although as of 2.0 Vite is now fully framework-agnostic, the official Vue plugin still provides first-class support for Vue's Single File Component format, covering all advanced features such as template asset reference resolving, `<script setup>`, `<style module>`, custom blocks and more. In addition, Vite provides fine-grained HMR for Vue SFCs. For example, updating the `<template>` or `<style>` of an SFC will perform hot updates without resetting its state.
+もともと Vite は、[Vue.js](https://vuejs.org/) のツールの将来の基礎を担う目的で開発されました。現在の2.0の Vite は完全にフレームワークに依存したものとなりましたが、公式の Vue プラグインは依然として Vue のシングルファイルコンポーネントのフォーマットに対して第1級のサポートを提供しています。テンプレートアセットリファレンス、`<script setup>`、`<style module>`、カスタムブロックを始めとした、あらゆる発展的な機能をカバーしています。さらに、Vite は Vue の SFC に対する細粒度の HMR を提供しています。たとえば、SFC の `<template>` や `<style>` を更新したとき、ステートをリセットせずにホットアップデートが実行可能です。
 
 ## WMR
 
-[WMR](https://github.com/preactjs/wmr) by the Preact team provides a similar feature set, and Vite 2.0's support for Rollup's plugin interface is inspired by it.
+Preact チームが開発した [WMR](https://github.com/preactjs/wmr) にも似たような機能群があり、Vite 2.0 の Rollup プラグインインターフェイスのサポートは、これに影響を受けています。
 
-WMR is mainly designed for [Preact](https://preactjs.com/) projects, and offers more integrated features such as pre-rendering. In terms of scope, it's closer to a Preact meta framework, with the same emphasis on compact size as Preact itself. If you are using Preact, WMR is likely going to offer a more fine-tuned experience. However, it's unlikely for WMR to prioritize support for other frameworks.
+WMR は主に [Preact](https://preactjs.com/) プロジェクトのために開発されたものであり、プリレンダリングなどのより統合された機能を提供しています。スコープの点では、Preact meta framework に近いものです。Preact を使用しているなら、WMR はより洗練された経験をもたらしてくれるでしょう。しかし、WMR が他のフレームワークのサポートを優先する可能性は低いです。
 
 ## @web/dev-server
 
-[@web/dev-server](https://modern-web.dev/docs/dev-server/overview/) (previously `es-dev-server`) is a great project and Vite 1.0's Koa-based server setup was inspired by it.
+[@web/dev-server](https://modern-web.dev/docs/dev-server/overview/)（旧称 `es-dev-server`）は素晴らしいプロジェクトです。Vite 1.0 の Koa ベースのサーバーのセットアップはこのプロジェクトに影響を受けたものです。
 
-`@web/dev-server` is a bit lower-level in terms of scope. It does not provide official framework integrations, and requires manually setting up a Rollup configuration for the production build.
+`@web/dev-server`はスコープの点では少し低レベルです。公式のフレームワークとの統合を提供しておらず、本番ビルドのためには Rollup の設定を手動でセットアップする必要があります。
 
-Overall, Vite is a more opinionated / higher-level tool that aims to provide a more out-of-the-box workflow. That said, the `@web` umbrella project contains many other excellent tools that may benefit Vite users as well.
+全体として、Vite はより out-of-the-box なワークフローを提供することを目的とした opinionated で高レベルのツールです。しかし、`@web` アンブレラプロジェクト内には、その他にも Vite ユーザーにも役に立つ優れたツールが存在します。


### PR DESCRIPTION
公式ドキュメントの「[Comparisons with Other No-Bundler Solutions | Vite](https://vitejs.dev/guide/comparisons.html)」に対応する `/guide/comparisons.md` を翻訳します。

Closes #3.