### PR TITLE
ページのヘッダなどの翻訳

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Vite',
-  description: '次世代のフロントエンドツール',
+  description: '次世代フロントエンドツール',
   head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }]],
   themeConfig: {
     repo: 'vitejs/vite',

--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'Vite',
-  description: 'Next Generation Frontend Tooling',
+  description: '次世代のフロントエンドツール',
   head: [['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }]],
   themeConfig: {
     repo: 'vitejs/vite',
@@ -21,11 +21,11 @@ module.exports = {
     },
 
     nav: [
-      { text: 'Guide', link: '/guide/' },
-      { text: 'Config', link: '/config/' },
-      { text: 'Plugins', link: '/plugins/' },
+      { text: 'ガイド', link: '/guide/' },
+      { text: '設定', link: '/config/' },
+      { text: 'プラグイン', link: '/plugins/' },
       {
-        text: 'Links',
+        text: 'リンク',
         items: [
           {
             text: 'Twitter',
@@ -62,7 +62,7 @@ module.exports = {
       // catch-all fallback
       '/': [
         {
-          text: 'Guide',
+          text: 'ガイド',
           children: [
             {
               text: 'Why Vite',
@@ -111,7 +111,7 @@ module.exports = {
           ]
         },
         {
-          text: 'APIs',
+          text: 'API',
           children: [
             {
               text: 'Plugin API',


### PR DESCRIPTION
Closes #13.

以下の箇所を翻訳しています。

- トップページの「Next Generation Frontend Tooling」
- ヘッダのテキスト
- ページ左のトップレベルの項目「Guide」「APIs」

**スクリーンショット**

![Screenshot_20210302-024159_Chrome](https://user-images.githubusercontent.com/1425259/109536726-70a55800-7b01-11eb-8b7f-23d24d1a2e8c.jpg)
![Screenshot_20210302-024440_Chrome](https://user-images.githubusercontent.com/1425259/109536744-74d17580-7b01-11eb-8ad3-3e0196ca31c9.jpg)
