### PR TITLE
apply vitejs/vite@2c41677

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -417,7 +417,7 @@ export default ({ command, mode }) => {
 
   The transform is performed with esbuild and the value should be a valid [esbuild target option](https://esbuild.github.io/api/#target). Custom targets can either be a ES version (e.g. `es2015`), a browser with version (e.g. `chrome58`), or an array of multiple target strings.
 
-  Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuid docs](https://esbuild.github.io/content-types/#javascript) for more details.
+  Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuild docs](https://esbuild.github.io/content-types/#javascript) for more details.
 
 ### build.polyfillDynamicImport
 


### PR DESCRIPTION
vitejs/vite@2c41677 の対応です
`esbuid` を `esbuild` に修正しました
close #51