### PR TITLE
apply vitejs/vite@130bf5a

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -569,6 +569,15 @@ export default ({ command, mode }) => {
 
   By default, linked packages not inside `node_modules` are not pre-bundled. Use this option to force a linked package to be pre-bundled.
 
+### optimizeDeps.keepNames
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  The bundler sometimes needs to rename symbols to avoid collisions.
+  Set this to `true` to keep the `name` property on functions and classes.
+  See [`keepNames`](https://esbuild.github.io/api/#keep-names).
+
 ## SSR Options
 
 :::warning Experimental


### PR DESCRIPTION
vitejs/vite@130bf5a の対応です
- config/index.md への内容追加。
- 元の PR では `packages/vite/src/node/optimizer/index.ts` にも変更がありますが、vite-docs-ja のリポジトリには存在しないので非対応です

close #52 