### PR TITLE
apply vitejs/vite@1e604d5

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -328,8 +328,12 @@ export default async ({ command, mode }) => {
 ### server.host
 
 - **Type:** `string`
+- **Default:** `'127.0.0.1'`
 
-  Specify server hostname.
+  Specify which IP addresses the server should listen on.
+  Set this to `0.0.0.0` to listen on all addresses, including LAN and public addresses.
+
+  This can be set via the CLI using `--host 0.0.0.0` or `--host`.
 
 ### server.port
 


### PR DESCRIPTION
vitejs/vite@1e604d5 の対応です。
`config/index.md` の差分だけ取り込みました（それ以外のファイルはこちらのリポジトリに存在しない）。
ご確認よろしくお願いいたします。

close #105