### PR TITLE
apply vitejs/vite@05fd1e2

### DIFF
--- a/config/index.md
+++ b/config/index.md
@@ -443,21 +443,6 @@ export default async ({ command, mode }) => {
 
   Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuild docs](https://esbuild.github.io/content-types/#javascript) for more details.
 
-### build.polyfillDynamicImport
-
-- **Type:** `boolean`
-- **Default:** `true` unless `build.target` is `'esnext'`
-
-  Whether to automatically inject [dynamic import polyfill](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
-
-  The polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-html custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
-
-  ```js
-  import 'vite/dynamic-import-polyfill'
-  ```
-
-  Note: the polyfill does **not** apply to [Library Mode](/guide/build#library-mode). If you need to support browsers without native dynamic import, you should probably avoid using it in your library.
-
 ### build.outDir
 
 - **Type:** `string`

--- a/config/index.md
+++ b/config/index.md
@@ -443,6 +443,23 @@ export default async ({ command, mode }) => {
 
   Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuild docs](https://esbuild.github.io/content-types/#javascript) for more details.
 
+### build.polyfillDynamicImport
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  Whether to automatically inject [dynamic import polyfill](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
+
+  If set to true, the polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-html custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
+
+  ```js
+  import 'vite/dynamic-import-polyfill'
+  ```
+
+  When using [`@vitejs/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), the plugin sets this option to `true` automatically.
+
+  Note: the polyfill does **not** apply to [Library Mode](/guide/build#library-mode). If you need to support browsers without native dynamic import, you should probably avoid using it in your library.
+
 ### build.outDir
 
 - **Type:** `string`

--- a/guide/backend-integration.md
+++ b/guide/backend-integration.md
@@ -20,13 +20,6 @@ Or you can follow these steps to configure it manually:
    }
    ```
 
-   Also remember to add the [dynamic import polyfill](/config/#build-polyfilldynamicimport) to your entry, since it will no longer be auto-injected:
-
-   ```js
-   // add the beginning of your app entry
-   import 'vite/dynamic-import-polyfill'
-   ```
-
 2. For development, inject the following in your server's HTML template (substitute `http://localhost:3000` with the local URL Vite is running at):
 
    ```html

--- a/guide/backend-integration.md
+++ b/guide/backend-integration.md
@@ -20,6 +20,13 @@ Or you can follow these steps to configure it manually:
    }
    ```
 
+   If you use [`@vitejs/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) or manually enable the [`build.dynamicImportPolyfill` option](/config/#build-polyfilldynamicimport), remember to add the [dynamic import polyfill](/config/#build-polyfilldynamicimport) to your entry, since it will no longer be auto-injected:
+
+   ```js
+   // add the beginning of your app entry
+   import 'vite/dynamic-import-polyfill'
+   ```
+
 2. For development, inject the following in your server's HTML template (substitute `http://localhost:3000` with the local URL Vite is running at):
 
    ```html

--- a/guide/build.md
+++ b/guide/build.md
@@ -4,14 +4,11 @@ When it is time to deploy your app for production, simply run the `vite build` c
 
 ## Browser Compatibility
 
-The production bundle assumes a baseline support for modern JavaScript. By default, all code is transpiled targeting [browsers with native ESM script tag support](https://caniuse.com/es6-module):
+The production bundle assumes support for modern JavaScript. By default, vite targets browsers which support the [native ESM script tag](https://caniuse.com/es6-module) and [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import). As a reference, vite uses this [browserslist](https://github.com/browserslist/browserslist) query:
 
-- Chrome >=61
-- Firefox >=60
-- Safari >=11
-- Edge >=16
-
-A lightweight [dynamic import polyfill](https://github.com/GoogleChromeLabs/dynamic-import-polyfill) is also automatically injected.
+```
+defaults and supports es6-module and supports es6-module-dynamic-import, not opera > 0, not samsung > 0, not and_qq > 0
+```
 
 You can specify custom targets via the [`build.target` config option](/config/#build-target), where the lowest target is `es2015`.
 

--- a/guide/comparisons.md
+++ b/guide/comparisons.md
@@ -16,7 +16,6 @@ Vite では、単一のバンドラー（Rollup）と深く結合することを
 - [ライブラリモード](./build#library-mode)
 - [自動的な CSS コードの分割](./features#css-code-splitting)
 - [最適化された非同期のチャンク読み込み](./features#async-chunk-loading-optimization)
-- [自動的な dynamic import の polyfill](./features#dynamic-import-polyfill)
 - 公式の [legacy モードプラグイン](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy)。このプラグインは、modern/legacy のデュアルバンドルを生成し、ブラウザの対応状況をもとに正しいバンドルを自動的に配信します。
 
 **より高速な依存関係の先読みビルド**

--- a/guide/features.md
+++ b/guide/features.md
@@ -304,12 +304,6 @@ import MyWorker from './worker?worker&inline'
 
 > 以下にリストされている機能は、ビルドプロセスの一部として自動的に適用され、無効にする場合を除いて、明示的に構成する必要はありません。
 
-### dynamic import される Polyfill
-
-Vite は、コード分割ポイントとして ES dynamic import を使用します。生成されたコードは、dynamic import を使用して非同期チャンクもロードします。しかし、ネイティブ ESM dynamic import サポートは、スクリプトタグを介して ESM よりも遅く着陸し、2つの機能の間にブラウザーサポートの不一致があります。Vite は、軽量の[dynamic import される Polyfill](https://github.com/GoogleChromeLabs/dynamic-import-polyfill) を自動的に挿入して、その違いを緩和します。
-
-ネイティブの動的インポートをサポートするブラウザのみを対象としていることがわかっている場合は、この機能を明示的に無効にすることができます。詳しくは [`build.polyfillDynamicImport`](/config/#build-polyfilldynamicimport) をご覧ください。
-
 ### CSS のコード分割
 
 Vite は、非同期チャンク内のモジュールによって使用される CSS を自動的に抽出し、そのための個別のファイルを生成します。CSS ファイルは、関連付けられた非同期チャンクが読み込まれるときに `<link>` タグを介して自動的に読み込まれ、[FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content#:~:text=A%20flash%20of%20unstyled%20content,before%20all%20information%20is%20retrieved.) を回避するために、CSS が読み込まれた後にのみ非同期チャンクが評価されることが保証されます。

--- a/guide/index.md
+++ b/guide/index.md
@@ -14,9 +14,7 @@ Vite はすぐに使える実用的なデフォルトが付属していて、プ
 
 ## ブラウザ対応
 
-- 開発向け: [ネイティブ ESM のダイナミックインポート対応](https://caniuse.com/es6-module-dynamic-import)が必要です。
-
-- プロダクション向け: デフォルトのビルドは [script タグでのネイティブ ESM 読込](https://caniuse.com/es6-module)に対応しているブラウザが対象です。レガシーブラウザは公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) でサポートされています。詳細は [Building for Production](./build) セクションをご覧ください。
+- The default build targets browsers that support both [native ESM via script tags](https://caniuse.com/es6-module) and [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import). Legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) - see the [Building for Production](./build) section for more details.
 
 ## 最初の Vite プロジェクトを生成する
 

--- a/guide/index.md
+++ b/guide/index.md
@@ -14,7 +14,7 @@ Vite はすぐに使える実用的なデフォルトが付属していて、プ
 
 ## ブラウザ対応
 
-- The default build targets browsers that support both [native ESM via script tags](https://caniuse.com/es6-module) and [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import). Legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) - see the [Building for Production](./build) section for more details.
+- デフォルトのビルドは [script タグでのネイティブ ESM 読込](https://caniuse.com/es6-module)と[ネイティブ ESM のダイナミックインポート](https://caniuse.com/es6-module-dynamic-import)の両方に対応しているブラウザが対象です。レガシーブラウザは公式の [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) でサポートされています。詳細は [Building for Production](./build) セクションをご覧ください。
 
 ## 最初の Vite プロジェクトを生成する
 


### PR DESCRIPTION
vitejs/vite@05fd1e2 の対応です。
こちらも docs ディレクトリのファイルのみ取り込んであります。

https://github.com/vuejs-jp/vite-docs-ja/commit/91f2a80e7c94ce32e26f5cfe2457a17176dcf95c ですべての差分を取り込んだ後に、https://github.com/vuejs-jp/vite-docs-ja/commit/fbf9de97b5d3482f3bb076c0e66ed96b170331ae で `guide/index.md` の変更箇所を再翻訳しています。


ご確認よろしくお願いいたします。

close #106

---
close #127
106 で削除された箇所に変更があったので反映しました